### PR TITLE
Show a favicon

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -97,6 +97,7 @@ button:focus {
 }
 
 #preview-stage {
+  overflow: hidden;
   position: relative;
   width: 256px;
   height: 256px;
@@ -166,10 +167,6 @@ button:focus {
 #result-image {
   width: 256px;
   height: 256px;
-}
-
-#preview-stage {
-  overflow: hidden;
 }
 
 .form, .preview {

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
 
     <title>Emojipress</title>
 
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="icon" type="image/png" href="squared-emoji-blank.png" />
     <link rel="stylesheet" href="app.css" />
 
     <script defer src="build/bundle.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import kebabCase from 'lodash.kebabcase';
 import domToImage from 'dom-to-image';
 
 var formWired = false;
+var faviconEl = document.querySelector('link[rel~=icon]');
 var textFieldEl = document.getElementById('text-field');
 var fontSizeSliderEl = document.getElementById('font-size-slider');
 var fontSizeLabelEl = document.getElementById('font-size-label');
@@ -131,6 +132,8 @@ function renderResult(name, dataURL) {
 
   downloadLinkEl.download = name;
   downloadLinkEl.href = dataURL;
+
+  faviconEl.href = dataURL;
 
   resultInstructionEl.classList.remove('hidden');
 }


### PR DESCRIPTION
favicon.png was 404-ing, so this points to the blank square as a default and then uses the generated data URI upon build click.