### PR TITLE
Hide text that overflows button boundary

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -138,7 +138,6 @@ button:focus {
 }
 
 #emoji-text {
-  width: 110%;
   text-align: center;
   text-transform: uppercase;
   color: transparent;
@@ -154,6 +153,7 @@ button:focus {
   top: 50%;
   transform: translate(0, -50%);
   width: 100%;
+  overflow: hidden;
 }
 
 .result {

--- a/public/app.css
+++ b/public/app.css
@@ -97,6 +97,7 @@ button:focus {
 }
 
 #preview-stage {
+  overflow: hidden;
   position: relative;
   width: 256px;
   height: 256px;
@@ -166,10 +167,6 @@ button:focus {
 #result-image {
   width: 256px;
   height: 256px;
-}
-
-#preview-stage {
-  overflow: hidden;
 }
 
 .form, .preview {

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
 
     <title>Emojipress</title>
 
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="icon" type="image/png" href="squared-emoji-blank.png" />
     <link rel="stylesheet" href="app.css" />
 
     <script defer src="build/bundle.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import kebabCase from 'lodash.kebabcase';
 import domToImage from 'dom-to-image';
 
 var formWired = false;
+var faviconEl = document.querySelector('link[rel~=icon]');
 var textFieldEl = document.getElementById('text-field');
 var fontSizeSliderEl = document.getElementById('font-size-slider');
 var fontSizeLabelEl = document.getElementById('font-size-label');
@@ -131,6 +132,8 @@ function renderResult(name, dataURL) {
 
   downloadLinkEl.download = name;
   downloadLinkEl.href = dataURL;
+
+  faviconEl.href = dataURL;
 
   resultInstructionEl.classList.remove('hidden');
 }


### PR DESCRIPTION
In some cases, long text might overflow and cause the calculated width of the element to be larger than 256px. This would cause the rendered button to not be square.